### PR TITLE
Update scala, sbt, scalatest, spark versions + travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: scala
+scala:
+  - 2.11.12
+jdk:
+  - oraclejdk8
+script: "sbt test"
+after_success: "sbt coverage test coveralls"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,40 @@
 sparktesting
 ============
+[![Build Status](https://travis-ci.org/malcolmgreaves/spark-testing.svg?branch=master)](https://travis-ci.org/malcolmgreaves/spark-testing)
 
-A tiny project that assists in writing Apache Spark based unittests.
+A tiny project that assists in writing Apache Spark based unit tests by 
+providing a single shared `SparkContext`.
+
+
+# For Developers
+
+Use `sbt` to `compile`, `test`, and view `coverage` reports 
+(with `sbt coverage test coverageReport`).
+
+# For Users
+
+### Proper `build.sbt` Configuration
+
+Ensure that `sbt` does _not_ fork and run tests in parallel when using this library.
+I.e. ensure that the following setting is present in your `build.sbt`:
+```sbt
+fork in Test := false
+```
+
+### Using a Shared Spark Context for Tests
+
+To make a scalatest class that uses a single, shared `SparkContext`, extend from the
+`SparkTesting` class. A stub that shows this extension is defined below:
+```scala
+import org.sparktest.test.SparkTesting
+
+class CustomSparkTest extends SparkTesting {
+
+  sparkTest("A test that uses a shared SparkContext") { sc =>
+    // sc: org.apache.spark.SparkContext
+    // your custom testing code that uses Spark goes here! :D
+    ???
+  }
+}
+```
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,54 +1,82 @@
-organization := "com.gonitro.research"
-
+organization := "io.malcolmgreaves"
 name := "spark-testing"
+version := "0.0.2"
 
-version := "0.0.1"
-
-// bring the sbt-dev-settings stuff into scope
-
-import com.nitro.build._
-
-import PublishHelpers._
-
-// use it to configure this build's scala and java settings
-
-lazy val jvmVer = JvmRuntime.Jvm7
-
-CompileScalaJava.librarySettings(CompileScalaJava.Config.spark)
-
-javaOptions := JvmRuntime.settings(jvmVer)
-
-// standard dependencies & their resolvers
-
+// dependencies & their resolvers
 resolvers ++= Seq(
   "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/",
-  "Nitro Nexus Releases" at "https://nexus.nitroplatform.com/nexus/content/repositories/releases/"
+  "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 )
-
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % "1.4.0",
-  "org.scalatest"    %% "scalatest"  % "2.2.4" 
+  "org.apache.spark" %% "spark-core" % "2.2.2",
+  "org.scalatest" %% "scalatest" % "3.0.5"
 )
 
-// publishing settings
 
-Publish.settings(
-  repo = Repository.github("Nitro", name.toString),
-  developers = 
-    Seq(
-      Dev("mgreaves", "Malcolm Greaves")
-    ),
-  art = ArtifactInfo.sonatype,
-  lic = License.apache20
+// scala compilation settings
+lazy val javaV = "1.8"
+scalaVersion in ThisBuild := "2.11.12"
+scalacOptions in ThisBuild := Seq(
+  "-deprecation",
+  "-feature",
+  "-unchecked",
+  s"-target:jvm-$javaV",
+  "-encoding",
+  "utf8",
+  "-language:postfixOps",
+  "-language:existentials",
+  "-language:higherKinds",
+  "-language:implicitConversions",
+  "-language:experimental.macros",
+  "-language:reflectiveCalls",
+  "-Yno-adapted-args",
+  "-Ywarn-value-discard",
+  "-Xlint",
+  "-Xfuture",
+  "-Ywarn-dead-code",
+  "-Xfatal-warnings" // Every warning is esclated to an error.
+)
+// java compilation settings
+javacOptions in ThisBuild := Seq("-source", javaV, "-target", javaV)
+javaOptions in ThisBuild := Seq(
+  "-server",
+  "-XX:+AggressiveOpts",
+  "-XX:+TieredCompilation",
+  "-XX:CompileThreshold=100",
+  "-Xmx3000M",
+  "-XX:+UseG1GC"
 )
 
-// unit test configuration
-
+// test, runtime settings
+//
+fork in run := false
 testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
-
 testOptions in Test += Tests.Argument("-oF")
-
 fork in Test := false
-
 parallelExecution in Test := true
 
+// publish settings
+//
+publishMavenStyle := true
+isSnapshot := false
+publishArtifact := true
+publishArtifact in Test := false
+publishTo := Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
+pomIncludeRepository := { _ => false }
+pomExtra := {
+  <url>https://github.com/malcolmgreaves/spark-testing</url>
+    <licenses>
+    </licenses>
+    <scm>
+      <url>git@ggithub.com:malcolmgreaves/spark-testing</url>
+      <connection>scm:git@github.com:malcolmgreaves/spark-testing.git</connection>
+    </scm>
+    <developers>
+      <developer>
+        <id>malcolmgreaves</id>
+        <name>Malcolm Greaves</name>
+        <email>greaves.malcolm@gmail.com</email>
+        <url>https://malcolmgreaves.io/</url>
+      </developer>
+    </developers>
+}

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ organization := "io.malcolmgreaves"
 name := "spark-testing"
 version := "0.0.2"
 
+coverageEnabled := true
+
 // dependencies & their resolvers
 resolvers ++= Seq(
   "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/",

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.5"
 )
 
-
 // scala compilation settings
 lazy val javaV = "1.8"
 scalaVersion in ThisBuild := "2.11.12"
@@ -61,8 +60,11 @@ publishMavenStyle := true
 isSnapshot := false
 publishArtifact := true
 publishArtifact in Test := false
-publishTo := Some("releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
-pomIncludeRepository := { _ => false }
+publishTo := Some(
+  "releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2")
+pomIncludeRepository := { _ =>
+  false
+}
 pomExtra := {
   <url>https://github.com/malcolmgreaves/spark-testing</url>
     <licenses>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,0 @@
-//resolvers += ("Nitro Nexus Releases" at "https://nexus.nitroplatform.com/nexus/content/repositories/releases/")
-
-//addSbtPlugin("com.gonitro.platform" % "sbt-nitro" % "0.1.0")
-
-addSbtPlugin("com.gonitro.platform" % "sbt-dev-settings" % "0.0.1")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")

--- a/src/main/scala/org/sparktest/test/SparkTesting.scala
+++ b/src/main/scala/org/sparktest/test/SparkTesting.scala
@@ -61,20 +61,20 @@ object SparkTesting extends org.scalatest.Tag("spark") {
   private[this] val mutex = new ReentrantReadWriteLock(true)
 
   /**
-   * WARNING :: Mutable! Global!
-   *
-   * Do not access this variable in any other manner except
-   * through the `sc` and `shutdown`methods. This is to ensure that
-   * there are no race conditions nor two spark contexts in the
-   * same JVM at one time.
-   */
+    * WARNING :: Mutable! Global!
+    *
+    * Do not access this variable in any other manner except
+    * through the `sc` and `shutdown`methods. This is to ensure that
+    * there are no race conditions nor two spark contexts in the
+    * same JVM at one time.
+    */
   private[this] var scInternal: SparkContext = _
 
   /**
-   * A Spark configuration that is in local mode with 3 cores, uses the
-   * Kryo serializer, and has the name "unit test XXX-XXXX" where the Xs
-   * are random String elements.
-   */
+    * A Spark configuration that is in local mode with 3 cores, uses the
+    * Kryo serializer, and has the name "unit test XXX-XXXX" where the Xs
+    * are random String elements.
+    */
   lazy val defaultSparkConf: SparkConf =
     new SparkConf()
       .setMaster("local[3]")
@@ -82,11 +82,12 @@ object SparkTesting extends org.scalatest.Tag("spark") {
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
 
   /**
-   * BLOCKING OPERATION
-   *
-   * Blocking must wait for interal write lock.
-   */
-  private[test] def sc(configIfInit: => SparkConf = defaultSparkConf): SparkContext =
+    * BLOCKING OPERATION
+    *
+    * Blocking must wait for interal write lock.
+    */
+  private[test] def sc(
+      configIfInit: => SparkConf = defaultSparkConf): SparkContext =
     try {
       mutex.writeLock.lock()
       if (scInternal == null) {
@@ -99,11 +100,11 @@ object SparkTesting extends org.scalatest.Tag("spark") {
     }
 
   /**
-   * BLOCKING OPERATION
-   *
-   *
-   * Blocking must wait for internal write lock.
-   */
+    * BLOCKING OPERATION
+    *
+    *
+    * Blocking must wait for internal write lock.
+    */
   private[test] def shutdown(): Unit =
     try {
       mutex.writeLock.lock()
@@ -133,44 +134,47 @@ trait SparkTesting extends FunSuite with BeforeAndAfterAll {
   }
 
   /**
-   * Calls the parent `test` method with the same parameters, except
-   * that there is only one tag that is used: `AltSparkTesting`.
-   */
-  final override def test(testName: String, ignored: Tag*)(testFun: => Unit): Unit =
+    * Calls the parent `test` method with the same parameters, except
+    * that there is only one tag that is used: `AltSparkTesting`.
+    */
+  final def test(testName: String, ignored: Tag*)(testFun: => Unit): Unit =
     super.test(testName, SparkTesting)(testFun)
 
   /**
-   * Calls the parent `ignore` method with the same parameters, except
-   * that there is only one tag that is used: `AltSparkTesting`.
-   */
-  final override def ignore(testName: String, ignored: Tag*)(testFun: => Unit): Unit =
+    * Calls the parent `ignore` method with the same parameters, except
+    * that there is only one tag that is used: `AltSparkTesting`.
+    */
+  final def ignore(testName: String, ignored: Tag*)(testFun: => Unit): Unit =
     super.ignore(testName, SparkTesting)(testFun)
 
   /**
-   * Runs as a FunSuite test: calls this overriden test method. Uses a shared
-   * SparkContext to run the supplied test function `testFun`.
-   */
+    * Runs as a FunSuite test: calls this overriden test method. Uses a shared
+    * SparkContext to run the supplied test function `testFun`.
+    */
   final def sparkTest(testName: String)(testFun: SparkContext => Any): Unit =
     test(testName) {
       SparkTesting.runWithSpark(testFun)
     }
 
   /**
-   * An ignored Spark-enabled unit test. Useful when one must temporarily
-   * disable a suite's test during gnarly debugging or development.
-   *
-   * NOTE:
-   *
-   * A stylistic break in naming convention is used in this method. Since its
-   * use is in test code, this method name should never see the light of day
-   * in any publicly facing APIs (or even internal ones). The concession in
-   * naming convention is done out of the following practical observation:
-   *
-   * It is easier to prepend "ignore_" to an existing spark test definition than it
-   * is to prepend "ignore", delete the "s", and then type in an "S" to keep
-   * camel case naming convention. ("ignore_sparkTest" vs. "ignoreSparkTest")
-   */
-  final def ignore_sparkTest(testName: String)(ignoredTestFun: SparkContext => Any): Unit =
-    ignore(testName) { () }
+    * An ignored Spark-enabled unit test. Useful when one must temporarily
+    * disable a suite's test during gnarly debugging or development.
+    *
+    * NOTE:
+    *
+    * A stylistic break in naming convention is used in this method. Since its
+    * use is in test code, this method name should never see the light of day
+    * in any publicly facing APIs (or even internal ones). The concession in
+    * naming convention is done out of the following practical observation:
+    *
+    * It is easier to prepend "ignore_" to an existing spark test definition than it
+    * is to prepend "ignore", delete the "s", and then type in an "S" to keep
+    * camel case naming convention. ("ignore_sparkTest" vs. "ignoreSparkTest")
+    */
+  final def ignore_sparkTest(testName: String)(
+      ignoredTestFun: SparkContext => Any): Unit =
+    ignore(testName) {
+      ()
+    }
 
 }

--- a/src/main/scala/org/sparktest/test/SparkTesting.scala
+++ b/src/main/scala/org/sparktest/test/SparkTesting.scala
@@ -1,13 +1,12 @@
-package com.nitro.test
+package org.sparktest.test
 
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
-import com.nitro.util.sync.WaitGroup
-import org.scalatest.{ Tag, BeforeAndAfterAll, FunSuite }
+import org.scalatest.{BeforeAndAfterAll, FunSuite, Tag}
 
 import scala.util.Random
-
-import org.apache.spark.{ SparkConf, SparkContext }
+import org.apache.spark.{SparkConf, SparkContext}
+import org.sparktest.util.sync.WaitGroup
 
 object SparkTesting extends org.scalatest.Tag("spark") {
 

--- a/src/main/scala/org/sparktest/util/sync/WaitGroup.scala
+++ b/src/main/scala/org/sparktest/util/sync/WaitGroup.scala
@@ -1,4 +1,4 @@
-package com.nitro.util.sync
+package org.sparktest.util.sync
 
 import java.util.concurrent.locks.ReentrantReadWriteLock
 

--- a/src/main/scala/org/sparktest/util/sync/WaitGroup.scala
+++ b/src/main/scala/org/sparktest/util/sync/WaitGroup.scala
@@ -3,20 +3,20 @@ package org.sparktest.util.sync
 import java.util.concurrent.locks.ReentrantReadWriteLock
 
 /**
- * A WaitGroup is a data structure used to synchronize many concurrently
- * executing operations, where the number of executing operations is
- * only known at runtime. This constraint precludes the use of a
- * Java concurrent CountDownLatch as the maximum number of concurrent
- * operations must be specified at compile time.
- *
- * Inspiration for this class, including its API, was motivated by the
- * WaitGroup struct in Go: http://golang.org/pkg/sync/#WaitGroup
- *
- * NOTE, design decision:
- * Chose as final class since it's highly mutable and shouldn't be mixed-in
- * nor extended. A `WaitGroup` has a incredibly narrow, well-defined purpose.
- * It should not be used for anything else.
- */
+  * A WaitGroup is a data structure used to synchronize many concurrently
+  * executing operations, where the number of executing operations is
+  * only known at runtime. This constraint precludes the use of a
+  * Java concurrent CountDownLatch as the maximum number of concurrent
+  * operations must be specified at compile time.
+  *
+  * Inspiration for this class, including its API, was motivated by the
+  * WaitGroup struct in Go: http://golang.org/pkg/sync/#WaitGroup
+  *
+  * NOTE, design decision:
+  * Chose as final class since it's highly mutable and shouldn't be mixed-in
+  * nor extended. A `WaitGroup` has a incredibly narrow, well-defined purpose.
+  * It should not be used for anything else.
+  */
 final class WaitGroup {
 
   // we want fair locking so the constructor param is true
@@ -25,14 +25,14 @@ final class WaitGroup {
   private[this] var counter = 0
 
   /**
-   * BLOCKING OPERATION.
-   *
-   * Register `k` operations with the wait group. Safely increments
-   * the internal counter by `k`, meaning that we expect a `done(k)`
-   * call or `k` `done(1)` calls in the future.
-   *
-   * Blocking must wait for internal write lock.
-   */
+    * BLOCKING OPERATION.
+    *
+    * Register `k` operations with the wait group. Safely increments
+    * the internal counter by `k`, meaning that we expect a `done(k)`
+    * call or `k` `done(1)` calls in the future.
+    *
+    * Blocking must wait for internal write lock.
+    */
   def add(k: Int): Unit = {
     lk.writeLock.lock()
     try {
@@ -44,18 +44,18 @@ final class WaitGroup {
   }
 
   /**
-   * BLOCKING OPERATION
-   *
-   * Acknowledge that `k` previosuly registered operations have completed.
-   * Safely decrements the internal counter by `k`, meaning that we are
-   * accounting for a `add(k)` call or `k` `add(1)` calls in the past.
-   *
-   * This method throws an `IllegalStateException` if we one calls `done`
-   * more than one has called `add`. I.e. an exception is thrown if the
-   * internal counter ever becomes negative.
-   *
-   * Blocking must wait for internal write lock.
-   */
+    * BLOCKING OPERATION
+    *
+    * Acknowledge that `k` previosuly registered operations have completed.
+    * Safely decrements the internal counter by `k`, meaning that we are
+    * accounting for a `add(k)` call or `k` `add(1)` calls in the past.
+    *
+    * This method throws an `IllegalStateException` if we one calls `done`
+    * more than one has called `add`. I.e. an exception is thrown if the
+    * internal counter ever becomes negative.
+    *
+    * Blocking must wait for internal write lock.
+    */
   def done(k: Int): Unit = {
     lk.writeLock.lock()
     try {
@@ -72,17 +72,17 @@ final class WaitGroup {
   type Millisecond = Int
 
   /**
-   * BLOCKING OPERATION
-   *
-   * Blocks until the internal counter is zero. The semantics here are that an
-   * executing thread will wait for all other threads "in" the waiting group
-   * to finish before it can proceed. This method sleeps for `sleepIncrement`
-   * milliseconds in-between each counter check. By default the wait is 1.3
-   * seconds. We suggest that one does not have too short of a wait time,
-   * otherwise one risks a busy wait loop!
-   *
-   * Blocking must wait for internal read lock.
-   */
+    * BLOCKING OPERATION
+    *
+    * Blocks until the internal counter is zero. The semantics here are that an
+    * executing thread will wait for all other threads "in" the waiting group
+    * to finish before it can proceed. This method sleeps for `sleepIncrement`
+    * milliseconds in-between each counter check. By default the wait is 1.3
+    * seconds. We suggest that one does not have too short of a wait time,
+    * otherwise one risks a busy wait loop!
+    *
+    * Blocking must wait for internal read lock.
+    */
   def waitUntilCompletion(sleepIncrement: Millisecond = 1300): Unit =
     while (!counterIsZero) {
       Thread.sleep(sleepIncrement)

--- a/src/test/scala/org/sparktest/test/GaussianSparkTest.scala
+++ b/src/test/scala/org/sparktest/test/GaussianSparkTest.scala
@@ -1,6 +1,4 @@
-package com.nitro.test
-
-import org.sparktest.test.SparkTesting
+package org.sparktest.test
 
 import scala.util.Random
 

--- a/src/test/scala/org/sparktest/test/GaussianSparkTest.scala
+++ b/src/test/scala/org/sparktest/test/GaussianSparkTest.scala
@@ -1,5 +1,7 @@
 package com.nitro.test
 
+import org.sparktest.test.SparkTesting
+
 import scala.util.Random
 
 class GaussianSparkTest extends SparkTesting {

--- a/src/test/scala/org/sparktest/test/HelloSparkTest.scala
+++ b/src/test/scala/org/sparktest/test/HelloSparkTest.scala
@@ -1,5 +1,7 @@
 package com.nitro.test
 
+import org.sparktest.test.SparkTesting
+
 class HelloSparkTest extends SparkTesting {
 
   sparkTest("Hello world!") { sc =>

--- a/src/test/scala/org/sparktest/test/HelloSparkTest.scala
+++ b/src/test/scala/org/sparktest/test/HelloSparkTest.scala
@@ -1,6 +1,4 @@
-package com.nitro.test
-
-import org.sparktest.test.SparkTesting
+package org.sparktest.test
 
 class HelloSparkTest extends SparkTesting {
 

--- a/src/test/scala/org/sparktest/test/UniformSparkTest.scala
+++ b/src/test/scala/org/sparktest/test/UniformSparkTest.scala
@@ -1,5 +1,7 @@
 package com.nitro.test
 
+import org.sparktest.test.SparkTesting
+
 import scala.util.Random
 
 class UniformSparkTest extends SparkTesting {

--- a/src/test/scala/org/sparktest/test/UniformSparkTest.scala
+++ b/src/test/scala/org/sparktest/test/UniformSparkTest.scala
@@ -1,6 +1,4 @@
-package com.nitro.test
-
-import org.sparktest.test.SparkTesting
+package org.sparktest.test
 
 import scala.util.Random
 


### PR DESCRIPTION
Updates scala (`2.11.12`), sbt (`1.2.8`), scalatest (`3.0.5`), and spark (`2.2.2`) versions. Additionally adds a Travis CI configuration & the `sbt-coverage` plugin.